### PR TITLE
Allow arc patch to update submodules

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -177,9 +177,7 @@ build_ghc_diff() {
   # -- Clone submodules
   echo -n " - Updating HEAD and grabbing submodules..."
   START=$(date +%s.%N)
-  (git checkout $COMMIT >> build-log.txt 2>&1 && \
-   git submodule init   >> build-log.txt 2>&1 && \
-   git submodule update >> build-log.txt 2>&1) &
+  (git checkout $COMMIT >> build-log.txt 2>&1) &
   waiting_progress 5
   END=$(date +%s.%N)
   if [ "$RESULT" != "0" ]; then

--- a/run.sh
+++ b/run.sh
@@ -177,6 +177,9 @@ build_ghc_diff() {
   # -- Clone submodules
   echo -n " - Updating HEAD and grabbing submodules..."
   START=$(date +%s.%N)
+  # we do not initialise submodules here to let arc patch change where
+  # submodules are pointing to. Thereby allowing patches affecting submodules to
+  # validate.
   (git checkout $COMMIT >> build-log.txt 2>&1) &
   waiting_progress 5
   END=$(date +%s.%N)


### PR DESCRIPTION
By not init'ing and update'ing submodules arc patch does the work and
thus updates to submodules, including changes to submodule urls, will
work smoothely.

---

Tested by applying https://phabricator.haskell.org/D1033 in two different ways: (since I have no local phab install)

As the run.sh script currently does

```
git clone GHC
git submodule init
git submodule update
arch patch D1033
```

Which fails with

```
...
Applied patch .gitmodules cleanly.
fatal: reference is not a tree: b18d17fc2bbafc6e8576764df8cf299b26fb1835
Unable to checkout 'b18d17fc2bbafc6e8576764df8cf299b26fb1835' in submodule path 'utils/haddock'
```

And the updated way:

```
git clone GHC
arc patch D1033
```

Here `arc patch` applies the patch, and then init's and update's the submodules, which makes everything work out OK.
